### PR TITLE
Fixed autofit material tiling being inconsistent between cameras

### DIFF
--- a/LingoSource/LMats.ls
+++ b/LingoSource/LMats.ls
@@ -94,6 +94,7 @@ on LRenderTileMaterial(l: number, nm: string, frntImg)
       end repeat
       
       tlsOrdered.sort()
+      delL = [:]
       tls = []
       repeat with q = 1 to tlsOrdered.count
         tls.add(tlsOrdered[q][2])
@@ -119,67 +120,70 @@ on LRenderTileMaterial(l: number, nm: string, frntImg)
       -- Draw the material
       if pickTiles.count > 0 then
          -- this is slightly different than comms code but will fix that later (in comms because comms version has bugs)
-        repeat while tls.count > 0 then
-          tl = tls[random(tls.count)]
-          
-          -- Shuffle tiles
-          randomTiles = []
-          repeat with thisTl in tileSelection then
-            randomTiles.append([random(1000), thisTl])
-          end repeat
-          randomTiles.sort()
-          
-          -- Find a tile to place
-          repeat with t = 1 to randomTiles.count then
-            testTile = randomTiles[t][2]
-            
-            -- Determine legality of placement
-            legalToPlace: number = true
-            repeat with a = 0 to testTile.sz.locH-1 then
-              repeat with b = 0 to testTile.sz.locV-1 then
-                testPoint = tl + point(a,b)
-                spec = testTile.specs[(b+1) + (a*testTile.sz.locV)]
-                
-                if spec <= 0 then next repeat -- ignore air and buffer
-                
-                if (tls.getPos(testPoint) = 0) then -- areas where material is not placed
-                  legalToPlace = false
-                  exit repeat
-                end if
-                
-                geoSpec = afaMvLvlEdit(testPoint, l)
-                if (geoSpec <> spec) then
-                  -- spec does not match on non-solid tile
-                  legalToPlace = false
-                  exit repeat
-                end if
-              end repeat
-              if (not legalToPlace) then exit repeat
+        repeat with tl in tls then
+          the randomSeed = seedForTile(tl, gLOprops.tileSeed + l)
+          if delL.findPos(tl)=void then
+            -- Shuffle tiles
+            randomTiles = []
+            repeat with thisTl in tileSelection then
+              randomTiles.append([random(1000), thisTl])
             end repeat
+            randomTiles.sort()
             
-            if legalToPlace then
-              -- Place tile
-              rootPos: point = tl + point(((testTile.sz.locH.float/2.0) + 0.4999).integer-1, ((testTile.sz.locV.float/2.0) + 0.4999).integer-1)
-              if(rootPos.inside(rect(gRenderCameraTilePos, gRenderCameraTilePos+point(100, 60))))then
-                frntImg = drawATileTile(rootPos.loch,rootPos.locV,l,testTile, frntImg, []) -- array argument required for chain holders. do not remove it!
-              end if
+            -- Find a tile to place
+            repeat with t = 1 to randomTiles.count then
+              testTile = randomTiles[t][2]
               
-              -- Remove tile ref
+              -- Determine legality of placement
+              legalToPlace: number = true
               repeat with a = 0 to testTile.sz.locH-1 then
                 repeat with b = 0 to testTile.sz.locV-1 then
                   testPoint = tl + point(a,b)
                   spec = testTile.specs[(b+1) + (a*testTile.sz.locV)]
-                  getPt: number = tls.getPos(testPoint)
-                  if getPt > 0 then
-                    tls.deleteAt(getPt)
+                  
+                  if spec <= 0 then next repeat -- ignore air and buffer
+                  
+                  if (tls.getPos(testPoint) = 0) then -- areas where material is not placed
+                    legalToPlace = false
+                    exit repeat
                   end if
+                  
+                  geoSpec = afaMvLvlEdit(testPoint, l)
+                  if (geoSpec <> spec) then
+                    -- spec does not match on non-solid tile
+                    legalToPlace = false
+                    exit repeat
+                  end if
+
+                  if (delL.findPos(testPoint)<>void) then -- tile has been placed here previously
+                    legalToPlace = false
+                    exit repeat
+                  end if
+
                 end repeat
+                if (not legalToPlace) then exit repeat
               end repeat
-              exit repeat
-            end if
-          end repeat
-          if tls.getPos(tl) then
-            tls.deleteAt(tls.getPos(tl))
+              
+              if legalToPlace then
+                -- Place tile
+                rootPos: point = tl + point(((testTile.sz.locH.float/2.0) + 0.4999).integer-1, ((testTile.sz.locV.float/2.0) + 0.4999).integer-1)
+                if(rootPos.inside(rect(gRenderCameraTilePos, gRenderCameraTilePos+point(100, 60))))then
+                  frntImg = drawATileTile(rootPos.loch,rootPos.locV,l,testTile, frntImg, []) -- array argument required for chain holders. do not remove it!
+                end if
+                
+                -- Remove tile ref
+                repeat with a = 0 to testTile.sz.locH-1 then
+                  repeat with b = 0 to testTile.sz.locV-1 then
+                    testPoint = tl + point(a,b)
+                    spec = testTile.specs[(b+1) + (a*testTile.sz.locV)]
+                    if (spec > -1) then
+                      delL[testPoint] = 1
+                    end if
+                  end repeat
+                end repeat
+                exit repeat
+              end if
+            end repeat
           end if
         end repeat
         the randomSeed = savSeed


### PR DESCRIPTION
I noticed a bug when using custom autofit materials where the tiling may not be consistent between cameras. Generally, if enough tiles of the material are off-screen, this bug will occur. To replicate for testing, draw a thick row of the material that stretches across the level, the tiles visible between two cameras shouldn't match, if done correctly.
To fix this bug, I borrowed some aspects of the random machines code that prevent this issue. I have done various tests and the bug appears to be fixed, but said tests haven't been extensive and I am not familiar with the language nor the codebase, so it's possible some bugs have snuck in. I apologise if such does occur.
I assume the same issue exists in comms - I'm unsure how to contribute, and this fix may be overwritten by subsequent updates, so perhaps it could be brought to their attention if needed.
wawa