### PR TITLE
Fix April longs

### DIFF
--- a/LingoSource/renderProps.ls
+++ b/LingoSource/renderProps.ls
@@ -1932,10 +1932,10 @@ on renderLongProp(qd, prop, data, dp)
             end if
             
             if canRender then 
-              if prop[1] = "Moss Drop A" then
+              if prop.nm = "Moss Drop A" then
                 member("layer" & restrict(points[t][2] - i, 0, 29) ).image.copyPixels(member("MossDropGraf").image, qd2, spriteRect, {#ink:36, #color:color(255,0,255)})
                 copyPixelsToEffectColor("A", restrict(points[t][2] - i, 0, 29), qd2, "MossDropGrad", spriteRect, 0.5, intensityPercent)
-              else if prop[1] = "Moss Drop B" then
+              else if prop.nm = "Moss Drop B" then
                 
                 member("layer" & restrict(points[t][2] - i, 0, 29) ).image.copyPixels(member("MossDropGraf").image, qd2, spriteRect, {#ink:36, #color:color(0,255,255)})
                 copyPixelsToEffectColor("B", restrict(points[t][2] - i, 0, 29), qd2, "MossDropGrad", spriteRect, 0.5, intensityPercent)
@@ -1967,7 +1967,8 @@ on renderLongProp(qd, prop, data, dp)
           repeat with t2 = 1 to (mossLength).integer / 2 then
             
             percent2 = (t2 / (mossLength / 2)).float
-            qd2 = lerp(qd, point(qd.locH, qd.locV + mossLength), percent2)
+            --qd2 = lerp(qd, point(qd.locH, qd.locV + mossLength), percent2)
+            qd2 = lerpPnt(qd, point(qd.locH, qd.locV + mossLength), percent2)
             depthCheck = true
             points2.add([qd2, depthRange - depthOffset])
             repeat while depthCheck then
@@ -1994,10 +1995,10 @@ on renderLongProp(qd, prop, data, dp)
         totalPoints = 0
         totalPoints = points.count
         totalLine = lerp(0.3, 0.7, random(100).float/100)
-        if prop[1] = "Moss Hang A" then 
+        if prop.nm = "Moss Hang A" then 
           eftc = "A"
           colr = color(255, 0, 255)
-        else if prop[1] = "Moss Hang B" then 
+        else if prop.nm = "Moss Hang B" then 
           eftc = "B"
           colr = color(0, 255, 255)
         else


### PR DESCRIPTION
- Replace `prop[1]`, where the first property is assumed to have the key `nm`, with `prop.nm`.
- Replace usage of `lerp` with points with `lerpPnt`.